### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout branch
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/kangqod/color-contrast-finder/security/code-scanning/1](https://github.com/kangqod/color-contrast-finder/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the `tests` job. Since the `tests` job only needs to read the repository contents to run tests, we will set the `contents` permission to `read`. This ensures that the job has the minimal permissions required to function correctly.

The changes will be made in the `.github/workflows/release.yml` file. Specifically, we will add the `permissions` block under the `tests` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
